### PR TITLE
Add various .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,69 @@ nvim
 
 spell/
 lazy-lock.json
+
+.DS_Store
+
+# Ignore compiled files
+*.o
+*.so
+*.pyc
+*.pyo
+
+# Ignore version control directories
+.git/
+.hg/
+.svn/
+
+# Ignore backup files
+*~
+*.bak
+*.swp
+*.swo
+
+# Ignore log files
+*.log
+
+# Ignore OS-specific files
+.DS_Store
+Thumbs.db
+
+# Ignore IDE-specific directories and files
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# Ignore Neovim-specific directories and files
+.netrwhist
+*.netrwhist
+.nvimlog
+*.nvimlog
+.nviminfo
+*.nviminfo
+
+# Ignore plugin-specific directories and files
+plugged/
+autoload/
+.luacache
+
+# Ignore local configuration files
+local/
+
+# Ignore session files
+sessions/
+
+# Ignore compiled Lua files
+lua/
+
+# Ignore temporary files
+tmp/
+temp/
+
+# Ignore test files and directories
+tests/
+spec/
+features/
+
+# Ignore documentation files
+doc/

--- a/init.lua
+++ b/init.lua
@@ -91,7 +91,7 @@ vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
 
 -- Set to true if you have a Nerd Font installed
-vim.g.have_nerd_font = false
+vim.g.have_nerd_font = true
 
 -- [[ Setting options ]]
 -- See `:help vim.opt`
@@ -277,11 +277,12 @@ require('lazy').setup({
     'folke/which-key.nvim',
     event = 'VimEnter', -- Sets the loading event to 'VimEnter'
     config = function() -- This is the function that runs, AFTER loading
-      require('which-key').setup()
+      require('which-key').setup {}
 
       -- Document existing key chains
       require('which-key').register {
         ['<leader>c'] = { name = '[C]ode', _ = 'which_key_ignore' },
+        ['<leader>n'] = { '<cmd>NvimTreeToggle<cr>', 'Explorer' },
         ['<leader>d'] = { name = '[D]ocument', _ = 'which_key_ignore' },
         ['<leader>r'] = { name = '[R]ename', _ = 'which_key_ignore' },
         ['<leader>s'] = { name = '[S]earch', _ = 'which_key_ignore' },
@@ -538,17 +539,17 @@ require('lazy').setup({
       --  - settings (table): Override the default settings passed when initializing the server.
       --        For example, to see the options for `lua_ls`, you could go to: https://luals.github.io/wiki/settings/
       local servers = {
-        -- clangd = {},
-        -- gopls = {},
-        -- pyright = {},
-        -- rust_analyzer = {},
+        clangd = {},
+        gopls = {},
+        pyright = {},
+        rust_analyzer = {},
         -- ... etc. See `:help lspconfig-all` for a list of all the pre-configured LSPs
         --
         -- Some languages (like typescript) have entire language plugins that can be useful:
         --    https://github.com/pmizio/typescript-tools.nvim
         --
         -- But for many setups, the LSP (`tsserver`) will work just fine
-        -- tsserver = {},
+        tsserver = {},
         --
 
         lua_ls = {
@@ -626,11 +627,11 @@ require('lazy').setup({
       formatters_by_ft = {
         lua = { 'stylua' },
         -- Conform can also run multiple formatters sequentially
-        -- python = { "isort", "black" },
+        python = { 'isort', 'black' },
         --
         -- You can use a sub-list to tell conform to run *until* a formatter
         -- is found.
-        -- javascript = { { "prettierd", "prettier" } },
+        javascript = { { 'prettierd', 'prettier' } },
       },
     },
   },
@@ -655,12 +656,12 @@ require('lazy').setup({
           -- `friendly-snippets` contains a variety of premade snippets.
           --    See the README about individual language/framework/plugin snippets:
           --    https://github.com/rafamadriz/friendly-snippets
-          -- {
-          --   'rafamadriz/friendly-snippets',
-          --   config = function()
-          --     require('luasnip.loaders.from_vscode').lazy_load()
-          --   end,
-          -- },
+          {
+            'rafamadriz/friendly-snippets',
+            config = function()
+              require('luasnip.loaders.from_vscode').lazy_load()
+            end,
+          },
         },
       },
       'saadparwaiz1/cmp_luasnip',
@@ -838,16 +839,16 @@ require('lazy').setup({
   --  Here are some example plugins that I've included in the Kickstart repository.
   --  Uncomment any of the lines below to enable them (you will need to restart nvim).
   --
-  -- require 'kickstart.plugins.debug',
-  -- require 'kickstart.plugins.indent_line',
-  -- require 'kickstart.plugins.lint',
+  require 'kickstart.plugins.debug',
+  require 'kickstart.plugins.indent_line',
+  require 'kickstart.plugins.lint',
 
   -- NOTE: The import below can automatically add your own plugins, configuration, etc from `lua/custom/plugins/*.lua`
   --    This is the easiest way to modularize your config.
   --
   --  Uncomment the following line and add your plugins to `lua/custom/plugins/*.lua` to get going.
   --    For additional information, see `:help lazy.nvim-lazy.nvim-structuring-your-plugins`
-  -- { import = 'custom.plugins' },
+  { import = 'custom.plugins' },
 }, {
   ui = {
     -- If you are using a Nerd Font: set icons to an empty table which will use the
@@ -869,6 +870,28 @@ require('lazy').setup({
     },
   },
 })
+
+-- disable netrw at the very start of your init.lua
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
+-- set termguicolors to enable highlight groups
+vim.opt.termguicolors = true
+
+require('nvim-tree').setup {
+  sort = {
+    sorter = 'case_sensitive',
+  },
+  view = {
+    width = 30,
+  },
+  renderer = {
+    group_empty = true,
+  },
+  filters = {
+    dotfiles = true,
+  },
+}
 
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -1,5 +1,6 @@
 -- You can add your own plugins here or in other files in this directory!
 --  I promise not to create any merge conflicts in this directory :)
 --
+
 -- See the kickstart.nvim README for more information
 return {}


### PR DESCRIPTION
This commit adds several new patterns to the .gitignore file to
ignore various types of files and directories, including compiled
files, version control directories, backup files, log files,
OS-specific files, IDE-specific files, Neovim-specific files,
plugin-specific files, local configuration files, session files,
compiled Lua files, temporary files, and test/documentation
files. These changes help keep the project directory clean and
organized.

fix: Enable Nerd Font support
This commit updates the Nerd Font setting in the init.lua file
from `false` to `true`, allowing for the use of Nerd Fonts in the
Neovim setup.

feat: Add new keymaps and document existing key chains
This commit adds a new keymap for toggling the NvimTree file
explorer under the `<leader>n` key. It also documents the existing
key chains for code, document, rename, and search actions using the
which-key plugin.

feat: Enable additional language servers
This commit enables several additional language servers, including
clangd, gopls, pyright, rust_analyzer, and tsserver, to provide
enhanced language support and code intelligence features for the
Neovim setup.

feat: Add additional code formatters
This commit adds support for additional code formatters, including
isort and black for Python, and prettierd and prettier for
JavaScript. These formatters help maintain consistent code styling
across the project.

feat: Load friendly-snippets plugin
This commit enables the `friendly-snippets` plugin, which provides
a wide variety of pre-made code snippets for various programming
languages and frameworks, improving developer productivity.

chore: Enable additional plugin modules
This commit enables the `kickstart.plugins