### PR TITLE
feat(init): Disable netrw, add Go to treesitter, and configure nvim-tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,6 @@ local/
 # Ignore session files
 sessions/
 
-# Ignore compiled Lua files
-lua/
 
 # Ignore temporary files
 tmp/

--- a/init.lua
+++ b/init.lua
@@ -87,6 +87,11 @@ P.S. You can delete this when you're done too. It's your config now! :)
 -- Set <space> as the leader key
 -- See `:help mapleader`
 --  NOTE: Must happen before plugins are loaded (otherwise wrong leader will be used)
+
+-- disable netrw at the very start of your init.lua
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
 
@@ -235,11 +240,10 @@ require('lazy').setup({
   -- Use `opts = {}` to force a plugin to be loaded.
   --
   --  This is equivalent to:
-  --    require('Comment').setup({})
-
+  -- require('Comment').setup {}
   -- "gc" to comment visual regions/lines
   { 'numToStr/Comment.nvim', opts = {} },
-
+  --
   -- Here is a more advanced example where we pass configuration
   -- options to `gitsigns.nvim`. This is equivalent to the following Lua:
   --    require('gitsigns').setup({ ... })
@@ -803,7 +807,7 @@ require('lazy').setup({
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
     opts = {
-      ensure_installed = { 'bash', 'c', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
+      ensure_installed = { 'go', 'bash', 'c', 'html', 'lua', 'luadoc', 'markdown', 'vim', 'vimdoc' },
       -- Autoinstall languages that are not installed
       auto_install = true,
       highlight = {
@@ -871,10 +875,6 @@ require('lazy').setup({
   },
 })
 
--- disable netrw at the very start of your init.lua
-vim.g.loaded_netrw = 1
-vim.g.loaded_netrwPlugin = 1
-
 -- set termguicolors to enable highlight groups
 vim.opt.termguicolors = true
 
@@ -886,11 +886,11 @@ require('nvim-tree').setup {
     width = 30,
   },
   renderer = {
-    group_empty = true,
+    group_empty = false,
   },
-  filters = {
-    dotfiles = true,
-  },
+  -- filters = {
+  --   dotfiles = false,
+  -- },
 }
 
 -- The line beneath this is called `modeline`. See `:help modeline`

--- a/lua/custom/plugins/auto_pairs.lua
+++ b/lua/custom/plugins/auto_pairs.lua
@@ -1,0 +1,10 @@
+return {
+
+  {
+    'windwp/nvim-autopairs',
+    event = 'InsertEnter',
+    config = true,
+    -- use opts = {} for passing setup options
+    -- this is equalent to setup({}) function
+  },
+}

--- a/lua/custom/plugins/lualine.lua
+++ b/lua/custom/plugins/lualine.lua
@@ -1,0 +1,10 @@
+return {
+  "nvim-lualine/lualine.nvim",
+  config = function()
+    require('lualine').setup({
+      options = {
+        theme = 'tokyonight'
+      }
+    })
+  end
+}

--- a/lua/custom/plugins/plugins.lua
+++ b/lua/custom/plugins/plugins.lua
@@ -1,0 +1,21 @@
+return {
+  -- Lualine
+  {
+    'nvim-lualine/lualine.nvim',
+    dependencies = {
+      'nvim-tree/nvim-web-devicons',
+    },
+  },
+  -- Nvimtree (File Explorer)
+  {
+    'nvim-tree/nvim-tree.lua',
+    version = '*',
+    lazy = false,
+    dependencies = {
+      'nvim-tree/nvim-web-devicons',
+    },
+    config = function()
+      require('nvim-tree').setup {}
+    end,
+  },
+}

--- a/lua/custom/plugins/tokyonight.lua
+++ b/lua/custom/plugins/tokyonight.lua
@@ -1,0 +1,13 @@
+return {
+  { 
+    "folke/tokyonight.nvim",
+    lazy = false,
+    name = "tokyonight", 
+    priority = 1000,
+    opts = {},
+    config = function()  
+      vim.cmd.colorscheme "tokyonight"
+    end
+  }
+}
+


### PR DESCRIPTION
# feat(init): Disable netrw, add Go to treesitter, and configure nvim-tree

This commit includes the following changes:

1. Disables the built-in Netrw plugin by setting `vim.g.loaded_netrw` and `vim.g.loaded_netrwPlugin` to `1`. This is done to avoid potential conflicts with other file management plugins.

2. Adds the "Go" language to the `ensure_installed` option in the Treesitter configuration. This ensures that the Go language support is automatically installed when Neovim starts.

3. Configures the `nvim-tree` plugin by:
   - Setting `group_empty` to `false` to show empty directories.
   - Commenting out the `filters.dotfiles` option, which was previously set to `true`. This change makes dotfiles visible in the file explorer and was not showing some fiels at all. 

These changes are made to enhance the overall development experience by improving file management, language support, and visual presentation in the Neovim editor.